### PR TITLE
More bindTo

### DIFF
--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
@@ -44,6 +44,80 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
+     * Local extension to subscribe [PresentationModel.Action] to the observable and add it to the subscriptions list
+     * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
+     * so use it ONLY in [onBindPresentationModel].
+     */
+    infix fun <T> Observable<T>.bindTo(action: PresentationModel.Action<T>) {
+        compositeUnbind.add(
+                this
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(action.consumer)
+        )
+    }
+
+    /**
+     * Local extension to subscribe to the [PresentationModel.State] and add it to the subscriptions list
+     * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
+     * so use it ONLY in [onBindPresentationModel].
+     *
+     * @since 1.x
+     */
+    infix fun <T> PresentationModel.State<T>.bindTo(consumer: Consumer<in T>) {
+        compositeUnbind.add(
+                this.observable
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(consumer)
+        )
+    }
+
+
+    /**
+     * Local extension to subscribe to the [PresentationModel.State] and add it to the subscriptions list
+     * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
+     * so use it ONLY in [onBindPresentationModel].
+     *
+     * @since 1.x
+     */
+    infix fun <T> PresentationModel.State<T>.bindTo(consumer: (T) -> Unit) {
+        compositeUnbind.add(
+                this.observable
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(consumer)
+        )
+    }
+
+    /**
+     * Local extension to subscribe to the [PresentationModel.Command] and add it to the subscriptions list
+     * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
+     * so use it ONLY in [onBindPresentationModel].
+     *
+     * @since 1.x
+     */
+    infix fun <T> PresentationModel.Command<T>.bindTo(consumer: Consumer<in T>) {
+        compositeUnbind.add(
+                this.observable
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(consumer)
+        )
+    }
+
+    /**
+     * Local extension to subscribe to the [PresentationModel.Command] and add it to the subscriptions list
+     * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
+     * so use it ONLY in [onBindPresentationModel].
+     *
+     * @since 1.x
+     */
+    infix fun <T> PresentationModel.Command<T>.bindTo(consumer: (T) -> Unit) {
+        compositeUnbind.add(
+                this.observable
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(consumer)
+        )
+    }
+
+    /**
      * Local extension to bind the [InputControl] to the [EditText][editText], use it ONLY in [onBindPresentationModel].
      */
     infix fun InputControl.bindTo(editText: EditText) {
@@ -86,6 +160,15 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      */
     infix fun <T> T.passTo(consumer: Consumer<T>) {
         consumer.accept(this)
+    }
+
+    /**
+     * Local extension to pass the value to the [PresentationModel.Action].
+     *
+     * @since 1.x
+     */
+    infix fun <T> T.passTo(action: PresentationModel.Action<T>) {
+        action.consumer.accept(this)
     }
 
 }

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
@@ -44,9 +44,11 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
-     * Local extension to subscribe [PresentationModel.Action] to the observable and add it to the subscriptions list
+     * Local extension to subscribe [Action][PresentationModel.Action] to the observable and add it to the subscriptions list
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
+     *
+     * @since 1.2
      */
     infix fun <T> Observable<T>.bindTo(action: PresentationModel.Action<T>) {
         compositeUnbind.add(
@@ -57,11 +59,11 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
-     * Local extension to subscribe to the [PresentationModel.State] and add it to the subscriptions list
+     * Local extension to subscribe to the [State][PresentationModel.State] and add it to the subscriptions list
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
      *
-     * @since 1.x
+     * @since 1.2
      */
     infix fun <T> PresentationModel.State<T>.bindTo(consumer: Consumer<in T>) {
         compositeUnbind.add(
@@ -73,11 +75,11 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
 
 
     /**
-     * Local extension to subscribe to the [PresentationModel.State] and add it to the subscriptions list
+     * Local extension to subscribe to the [State][PresentationModel.State] and add it to the subscriptions list
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
      *
-     * @since 1.x
+     * @since 1.2
      */
     infix fun <T> PresentationModel.State<T>.bindTo(consumer: (T) -> Unit) {
         compositeUnbind.add(
@@ -88,7 +90,7 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
-     * Local extension to subscribe to the [PresentationModel.Command] and add it to the subscriptions list
+     * Local extension to subscribe to the [Command][PresentationModel.Command] and add it to the subscriptions list
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
      *
@@ -103,7 +105,7 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
-     * Local extension to subscribe to the [PresentationModel.Command] and add it to the subscriptions list
+     * Local extension to subscribe to the [Command][PresentationModel.Command] and add it to the subscriptions list
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
      *
@@ -163,9 +165,9 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
-     * Local extension to pass the value to the [PresentationModel.Action].
+     * Local extension to pass the value to the [Action][PresentationModel.Action].
      *
-     * @since 1.x
+     * @since 1.2
      */
     infix fun <T> T.passTo(action: PresentationModel.Action<T>) {
         action.consumer.accept(this)

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
@@ -23,11 +23,9 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * so use it ONLY in [onBindPresentationModel].
      */
     infix fun <T> Observable<T>.bindTo(consumer: Consumer<in T>) {
-        compositeUnbind.add(
-                this
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(consumer)
-        )
+        this.observeOn(AndroidSchedulers.mainThread())
+                .subscribe(consumer)
+                .untilUnbind()
     }
 
     /**
@@ -36,11 +34,9 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * so use it ONLY in [onBindPresentationModel].
      */
     infix fun <T> Observable<T>.bindTo(consumer: (T) -> Unit) {
-        compositeUnbind.add(
-                this
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(consumer)
-        )
+        this.observeOn(AndroidSchedulers.mainThread())
+                .subscribe(consumer)
+                .untilUnbind()
     }
 
     /**
@@ -51,11 +47,9 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * @since 1.2
      */
     infix fun <T> Observable<T>.bindTo(action: PresentationModel.Action<T>) {
-        compositeUnbind.add(
-                this
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(action.consumer)
-        )
+        this.observeOn(AndroidSchedulers.mainThread())
+                .subscribe(action.consumer)
+                .untilUnbind()
     }
 
     /**
@@ -66,11 +60,10 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * @since 1.2
      */
     infix fun <T> PresentationModel.State<T>.bindTo(consumer: Consumer<in T>) {
-        compositeUnbind.add(
-                this.observable
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(consumer)
-        )
+        this.observable
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(consumer)
+                .untilUnbind()
     }
 
 
@@ -82,11 +75,10 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * @since 1.2
      */
     infix fun <T> PresentationModel.State<T>.bindTo(consumer: (T) -> Unit) {
-        compositeUnbind.add(
-                this.observable
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(consumer)
-        )
+        this.observable
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(consumer)
+                .untilUnbind()
     }
 
     /**
@@ -94,14 +86,13 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
      *
-     * @since 1.x
+     * @since 1.2
      */
     infix fun <T> PresentationModel.Command<T>.bindTo(consumer: Consumer<in T>) {
-        compositeUnbind.add(
-                this.observable
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(consumer)
-        )
+        this.observable
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(consumer)
+                .untilUnbind()
     }
 
     /**
@@ -109,14 +100,13 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
      * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
      * so use it ONLY in [onBindPresentationModel].
      *
-     * @since 1.x
+     * @since 1.2
      */
     infix fun <T> PresentationModel.Command<T>.bindTo(consumer: (T) -> Unit) {
-        compositeUnbind.add(
-                this.observable
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(consumer)
-        )
+        this.observable
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(consumer)
+                .untilUnbind()
     }
 
     /**

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/base/Screen.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/base/Screen.kt
@@ -21,7 +21,7 @@ abstract class Screen<PM : ScreenPresentationModel> : PmSupportFragment<PM>(), B
     }
 
     override fun onBindPresentationModel(pm: PM) {
-        pm.errorDialog.bindTo { message, _ ->
+        pm.errorDialog bindTo { message, _ ->
             AlertDialog.Builder(context)
                     .setMessage(message)
                     .setPositiveButton(R.string.ok_button, null)

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/confirmation/CodeConfirmationScreen.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/confirmation/CodeConfirmationScreen.kt
@@ -33,11 +33,12 @@ class CodeConfirmationScreen : Screen<CodeConfirmationPm>() {
 
     override fun onBindPresentationModel(pm: CodeConfirmationPm) {
         super.onBindPresentationModel(pm)
-        pm.code bindTo codeEditLayout
-        pm.inProgress.observable bindTo progressConsumer
-        pm.doneButtonEnabled.observable bindTo doneButton.enabled()
 
-        navButton.clicks().bindTo(pm.backAction.consumer)
+        pm.code bindTo codeEditLayout
+        pm.inProgress bindTo progressConsumer
+        pm.doneButtonEnabled bindTo doneButton.enabled()
+
+        navButton.clicks() bindTo pm.backAction
 
         Observable
                 .merge(
@@ -47,7 +48,7 @@ class CodeConfirmationScreen : Screen<CodeConfirmationPm>() {
                                 .filter { it == EditorInfo.IME_ACTION_SEND }
                                 .map { Unit }
                 )
-                .bindTo(pm.doneAction.consumer)
+                .bindTo(pm.doneAction)
 
     }
 

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/country/ChooseCountryPm.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/country/ChooseCountryPm.kt
@@ -15,7 +15,7 @@ class ChooseCountryPm(private val phoneUtil: PhoneUtil) : ScreenPresentationMode
 
     val countries = State<List<Country>>()
     val mode = State(SEARCH_CLOSED)
-    val searchQuery = inputControl()
+    val searchQueryInput = inputControl()
 
     override val backAction = Action<Unit>()
 
@@ -33,10 +33,10 @@ class ChooseCountryPm(private val phoneUtil: PhoneUtil) : ScreenPresentationMode
 
         clearAction.observable
                 .subscribe {
-                    if (searchQuery.text.value.isEmpty()) {
+                    if (searchQueryInput.text.value.isEmpty()) {
                         mode.consumer.accept(SEARCH_CLOSED)
                     } else {
-                        searchQuery.text.consumer.accept("")
+                        searchQueryInput.text.consumer.accept("")
                     }
                 }
                 .untilDestroy()
@@ -51,7 +51,7 @@ class ChooseCountryPm(private val phoneUtil: PhoneUtil) : ScreenPresentationMode
                 }
                 .untilDestroy()
 
-        searchQuery.text.observable
+        searchQueryInput.text.observable
                 .debounce(100, TimeUnit.MILLISECONDS)
                 .map { query ->
                     val regex = "${query.toLowerCase()}.*".toRegex()

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/country/ChooseCountryScreen.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/country/ChooseCountryScreen.kt
@@ -36,27 +36,27 @@ class ChooseCountryScreen : Screen<ChooseCountryPm>() {
     override fun onBindPresentationModel(pm: ChooseCountryPm) {
         super.onBindPresentationModel(pm)
 
-        pm.mode.observable.bindTo {
+        pm.mode bindTo {
             if (it == Mode.SEARCH_OPENED) {
                 toolbarTitle.visible(false)
-                searchQuery.visible(true)
-                searchQuery.showKeyboard()
+                searchQueryEdit.visible(true)
+                searchQueryEdit.showKeyboard()
                 searchButton.visible(false)
                 clearButton.visible(true)
             } else {
                 toolbarTitle.visible(true)
-                searchQuery.visible(false)
-                searchQuery.hideKeyboard()
+                searchQueryEdit.visible(false)
+                searchQueryEdit.hideKeyboard()
                 searchButton.visible(true)
                 clearButton.visible(false)
             }
         }
 
-        pm.searchQuery.bindTo(searchQuery)
-        pm.countries.observable.bindTo { countriesAdapter.setData(it) }
+        pm.searchQueryInput bindTo searchQueryEdit
+        pm.countries bindTo { countriesAdapter.setData(it) }
 
-        searchButton.clicks().bindTo(pm.openSearchAction.consumer)
-        clearButton.clicks().bindTo(pm.clearAction.consumer)
-        navButton.clicks().bindTo(pm.backAction.consumer)
+        searchButton.clicks() bindTo pm.openSearchAction
+        clearButton.clicks() bindTo pm.clearAction
+        navButton.clicks() bindTo pm.backAction
     }
 }

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/main/MainScreen.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/main/MainScreen.kt
@@ -19,16 +19,17 @@ class MainScreen : Screen<MainPm>() {
     override fun onBindPresentationModel(pm: MainPm) {
         super.onBindPresentationModel(pm)
 
-        pm.logoutDialog.bindTo { _, dc ->
+        pm.logoutDialog bindTo { _, dc ->
             AlertDialog.Builder(context)
                     .setMessage("Are you sure you want to log out?")
                     .setPositiveButton("ok", { _, _ -> dc.sendResult(Ok) })
                     .setNegativeButton("cancel", { _, _ -> dc.sendResult(Cancel) })
                     .create()
         }
-        pm.inProgress.observable.bindTo(progressConsumer)
 
-        logoutButton.clicks().bindTo(pm.logoutAction.consumer)
+        pm.inProgress bindTo progressConsumer
+
+        logoutButton.clicks() bindTo pm.logoutAction
     }
 
 }

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/phone/AuthByPhoneScreen.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/ui/phone/AuthByPhoneScreen.kt
@@ -26,16 +26,16 @@ class AuthByPhoneScreen : Screen<AuthByPhonePm>() {
         super.onBindPresentationModel(pm)
         pm.countryCode bindTo editCountryCodeLayout
         pm.phoneNumber bindTo editPhoneNumberLayout
-        pm.chosenCountry.observable.bindTo {
+        pm.chosenCountry bindTo {
             countryName.text = it.name
         }
 
-        pm.inProgress.observable bindTo progressConsumer
-        pm.doneButtonEnabled.observable bindTo doneButton.enabled()
+        pm.inProgress bindTo progressConsumer
+        pm.doneButtonEnabled bindTo doneButton.enabled()
 
-        pm.phoneNumberFocus.observable.bindTo { phoneNumberEdit.requestFocus() }
+        pm.phoneNumberFocus bindTo { phoneNumberEdit.requestFocus() }
 
-        countryName.clicks().bindTo(pm.countryClicks.consumer)
+        countryName.clicks() bindTo pm.countryClicks
 
         Observable
                 .merge(
@@ -45,12 +45,12 @@ class AuthByPhoneScreen : Screen<AuthByPhonePm>() {
                                 .filter { it == EditorInfo.IME_ACTION_SEND }
                                 .map { Unit }
                 )
-                .bindTo(pm.doneAction.consumer)
+                .bindTo(pm.doneAction)
 
     }
 
     fun onCountryChosen(country: Country) {
-        presentationModel.chooseCountryAction.consumer.accept(country)
+        country passTo presentationModel.chooseCountryAction
     }
 
     override fun onResume() {

--- a/sample/src/main/res/layout/screen_choose_country.xml
+++ b/sample/src/main/res/layout/screen_choose_country.xml
@@ -18,7 +18,7 @@
             android:text="@string/choose_country_screen_title"/>
 
         <EditText
-            android:id="@+id/searchQuery"
+            android:id="@+id/searchQueryEdit"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginLeft="16dp"


### PR DESCRIPTION
Allows you to write instead of

`pm.inProgress.observable bindTo swipeRefreshLayout.refreshing()`
`pm.data.observable bindTo { }`
`swipeRefreshLayout.refreshes() bindTo pm.refreshAction.consumer`

shorter bindings

`pm.inProgress bindTo swipeRefreshLayout.refreshing()`
`pm.data bindTo { }`
`swipeRefreshLayout.refreshes() bindTo pm.refreshAction`