### PR TITLE
Navigation messages dispatching thread

### DIFF
--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmActivityDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmActivityDelegate.kt
@@ -21,7 +21,7 @@ import me.jeevuz.outlast.predefined.ActivityOutlast
  * to the corresponding ones in this class.
  */
 class PmActivityDelegate<PM, A>(private val pmView: A)
-where PM : PresentationModel, A : Activity, A : PmView<PM> {
+    where PM : PresentationModel, A : Activity, A : PmView<PM> {
 
     private lateinit var outlast: ActivityOutlast<PmWrapper<PM>>
     internal lateinit var pmBinder: PmBinder<PM>
@@ -36,15 +36,17 @@ where PM : PresentationModel, A : Activity, A : PmView<PM> {
      */
     fun onCreate(savedInstanceState: Bundle?) {
         outlast = ActivityOutlast(pmView,
-                                  Outlasting.Creator<PmWrapper<PM>> {
-                                      PmWrapper(pmView.providePresentationModel())
-                                  },
-                                  savedInstanceState)
+            Outlasting.Creator<PmWrapper<PM>> {
+                PmWrapper(pmView.providePresentationModel())
+            },
+            savedInstanceState)
         presentationModel // Create lazy presentation model now
         pmBinder = PmBinder(presentationModel, pmView)
-        navigationMessagesDisposable = presentationModel.navigationMessages.observable.observeOn(AndroidSchedulers.mainThread()).subscribe {
-            navigationMessagesDispatcher.dispatch(it)
-        }
+        navigationMessagesDisposable = presentationModel.navigationMessages.observable
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                navigationMessagesDispatcher.dispatch(it)
+            }
     }
 
     /**

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmActivityDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmActivityDelegate.kt
@@ -21,7 +21,7 @@ import me.jeevuz.outlast.predefined.ActivityOutlast
  * to the corresponding ones in this class.
  */
 class PmActivityDelegate<PM, A>(private val pmView: A)
-    where PM : PresentationModel, A : Activity, A : PmView<PM> {
+where PM : PresentationModel, A : Activity, A : PmView<PM> {
 
     private lateinit var outlast: ActivityOutlast<PmWrapper<PM>>
     internal lateinit var pmBinder: PmBinder<PM>
@@ -36,10 +36,10 @@ class PmActivityDelegate<PM, A>(private val pmView: A)
      */
     fun onCreate(savedInstanceState: Bundle?) {
         outlast = ActivityOutlast(pmView,
-            Outlasting.Creator<PmWrapper<PM>> {
-                PmWrapper(pmView.providePresentationModel())
-            },
-            savedInstanceState)
+                                  Outlasting.Creator<PmWrapper<PM>> {
+                                      PmWrapper(pmView.providePresentationModel())
+                                  },
+                                  savedInstanceState)
         presentationModel // Create lazy presentation model now
         pmBinder = PmBinder(presentationModel, pmView)
         navigationMessagesDisposable = presentationModel.navigationMessages.observable

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmActivityDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmActivityDelegate.kt
@@ -2,6 +2,7 @@ package me.dmdev.rxpm.delegate
 
 import android.app.Activity
 import android.os.Bundle
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import me.dmdev.rxpm.PmView
 import me.dmdev.rxpm.PresentationModel
@@ -41,7 +42,7 @@ where PM : PresentationModel, A : Activity, A : PmView<PM> {
                                   savedInstanceState)
         presentationModel // Create lazy presentation model now
         pmBinder = PmBinder(presentationModel, pmView)
-        navigationMessagesDisposable = presentationModel.navigationMessages.observable.subscribe {
+        navigationMessagesDisposable = presentationModel.navigationMessages.observable.observeOn(AndroidSchedulers.mainThread()).subscribe {
             navigationMessagesDispatcher.dispatch(it)
         }
     }

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmControllerDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmControllerDelegate.kt
@@ -19,7 +19,7 @@ import me.dmdev.rxpm.navigation.ControllerNavigationMessageDispatcher
  * to the corresponding ones in this class.
  */
 class PmControllerDelegate<PM, C>(private val pmView: C)
-where PM : PresentationModel, C : Controller, C : PmView<PM> {
+    where PM : PresentationModel, C : Controller, C : PmView<PM> {
 
     internal val pmBinder: PmBinder<PM> by lazy(LazyThreadSafetyMode.NONE) { PmBinder(presentationModel, pmView) }
     private var created = false
@@ -31,9 +31,11 @@ where PM : PresentationModel, C : Controller, C : PmView<PM> {
 
     private fun onCreate() {
         presentationModel.lifecycleConsumer.accept(Lifecycle.CREATED)
-        navigationMessagesDisposable = presentationModel.navigationMessages.observable.observeOn(AndroidSchedulers.mainThread()).subscribe {
-            navigationMessageDispatcher.dispatch(it)
-        }
+        navigationMessagesDisposable = presentationModel.navigationMessages.observable
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                navigationMessageDispatcher.dispatch(it)
+            }
     }
 
     /**

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmControllerDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmControllerDelegate.kt
@@ -5,7 +5,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import me.dmdev.rxpm.PmView
 import me.dmdev.rxpm.PresentationModel
-import me.dmdev.rxpm.PresentationModel.*
+import me.dmdev.rxpm.PresentationModel.Lifecycle
 import me.dmdev.rxpm.base.PmController
 import me.dmdev.rxpm.navigation.ControllerNavigationMessageDispatcher
 
@@ -19,7 +19,7 @@ import me.dmdev.rxpm.navigation.ControllerNavigationMessageDispatcher
  * to the corresponding ones in this class.
  */
 class PmControllerDelegate<PM, C>(private val pmView: C)
-    where PM : PresentationModel, C : Controller, C : PmView<PM> {
+where PM : PresentationModel, C : Controller, C : PmView<PM> {
 
     internal val pmBinder: PmBinder<PM> by lazy(LazyThreadSafetyMode.NONE) { PmBinder(presentationModel, pmView) }
     private var created = false

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmControllerDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmControllerDelegate.kt
@@ -1,10 +1,11 @@
 package me.dmdev.rxpm.delegate
 
 import com.bluelinelabs.conductor.Controller
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import me.dmdev.rxpm.PmView
 import me.dmdev.rxpm.PresentationModel
-import me.dmdev.rxpm.PresentationModel.Lifecycle
+import me.dmdev.rxpm.PresentationModel.*
 import me.dmdev.rxpm.base.PmController
 import me.dmdev.rxpm.navigation.ControllerNavigationMessageDispatcher
 
@@ -30,7 +31,7 @@ where PM : PresentationModel, C : Controller, C : PmView<PM> {
 
     private fun onCreate() {
         presentationModel.lifecycleConsumer.accept(Lifecycle.CREATED)
-        navigationMessagesDisposable = presentationModel.navigationMessages.observable.subscribe {
+        navigationMessagesDisposable = presentationModel.navigationMessages.observable.observeOn(AndroidSchedulers.mainThread()).subscribe {
             navigationMessageDispatcher.dispatch(it)
         }
     }

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmSupportFragmentDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmSupportFragmentDelegate.kt
@@ -21,7 +21,7 @@ import me.jeevuz.outlast.predefined.FragmentOutlast
  * to the corresponding ones in this class.
  */
 class PmSupportFragmentDelegate<PM, F>(private val pmView: F)
-    where PM : PresentationModel, F : Fragment, F : PmView<PM> {
+where PM : PresentationModel, F : Fragment, F : PmView<PM> {
 
     private lateinit var outlast: FragmentOutlast<PmWrapper<PM>>
     internal lateinit var pmBinder: PmBinder<PM>
@@ -36,10 +36,10 @@ class PmSupportFragmentDelegate<PM, F>(private val pmView: F)
      */
     fun onCreate(savedInstanceState: Bundle?) {
         outlast = FragmentOutlast(pmView,
-            Outlasting.Creator<PmWrapper<PM>> {
-                PmWrapper(pmView.providePresentationModel())
-            },
-            savedInstanceState)
+                                  Outlasting.Creator<PmWrapper<PM>> {
+                                      PmWrapper(pmView.providePresentationModel())
+                                  },
+                                  savedInstanceState)
         presentationModel // Create lazy presentation model now
         pmBinder = PmBinder(presentationModel, pmView)
         navigationMessagesDisposable = presentationModel.navigationMessages.observable

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmSupportFragmentDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmSupportFragmentDelegate.kt
@@ -2,6 +2,7 @@ package me.dmdev.rxpm.delegate
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import me.dmdev.rxpm.PmView
 import me.dmdev.rxpm.PresentationModel
@@ -41,7 +42,7 @@ where PM : PresentationModel, F : Fragment, F : PmView<PM> {
                                   savedInstanceState)
         presentationModel // Create lazy presentation model now
         pmBinder = PmBinder(presentationModel, pmView)
-        navigationMessagesDisposable = presentationModel.navigationMessages.observable.subscribe {
+        navigationMessagesDisposable = presentationModel.navigationMessages.observable.observeOn(AndroidSchedulers.mainThread()).subscribe {
             navigationMessageDispatcher.dispatch(it)
         }
     }

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmSupportFragmentDelegate.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/delegate/PmSupportFragmentDelegate.kt
@@ -21,7 +21,7 @@ import me.jeevuz.outlast.predefined.FragmentOutlast
  * to the corresponding ones in this class.
  */
 class PmSupportFragmentDelegate<PM, F>(private val pmView: F)
-where PM : PresentationModel, F : Fragment, F : PmView<PM> {
+    where PM : PresentationModel, F : Fragment, F : PmView<PM> {
 
     private lateinit var outlast: FragmentOutlast<PmWrapper<PM>>
     internal lateinit var pmBinder: PmBinder<PM>
@@ -36,15 +36,17 @@ where PM : PresentationModel, F : Fragment, F : PmView<PM> {
      */
     fun onCreate(savedInstanceState: Bundle?) {
         outlast = FragmentOutlast(pmView,
-                                  Outlasting.Creator<PmWrapper<PM>> {
-                                      PmWrapper(pmView.providePresentationModel())
-                                  },
-                                  savedInstanceState)
+            Outlasting.Creator<PmWrapper<PM>> {
+                PmWrapper(pmView.providePresentationModel())
+            },
+            savedInstanceState)
         presentationModel // Create lazy presentation model now
         pmBinder = PmBinder(presentationModel, pmView)
-        navigationMessagesDisposable = presentationModel.navigationMessages.observable.observeOn(AndroidSchedulers.mainThread()).subscribe {
-            navigationMessageDispatcher.dispatch(it)
-        }
+        navigationMessagesDisposable = presentationModel.navigationMessages.observable
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                navigationMessageDispatcher.dispatch(it)
+            }
     }
 
     /**


### PR DESCRIPTION
I most cases navigation should be handled in android main thread but currently we should manually switch it at presentation model or should call activity.runOnUiThread, this pr adds observeOn operator to navigation messages stream with main thread scheduler.