### PR TITLE
Expose DialogControl's displayed property and fix #26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.61'
+    ext.kotlinVersion = '1.2.70'
     repositories {
         jcenter()
         google()

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/AndroidPmView.kt
@@ -141,10 +141,19 @@ interface AndroidPmView<PM : PresentationModel> : PmView<PM> {
     }
 
     /**
-     * Local extension to pass an empty value to the [Consumer].
+     * Local function to pass an empty value to the [Consumer].
      */
     infix fun passTo(consumer: Consumer<Unit>) {
         consumer.accept(Unit)
+    }
+
+    /**
+     * Local function to pass an empty value to the [Action][PresentationModel.Action]
+     *
+     * @since 1.2
+     */
+    infix fun passTo(action: PresentationModel.Action<Unit>) {
+        action.consumer.accept(Unit)
     }
 
     /**

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/widget/DialogControl.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/widget/DialogControl.kt
@@ -7,8 +7,8 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import me.dmdev.rxpm.AndroidPmView
 import me.dmdev.rxpm.PresentationModel
-import me.dmdev.rxpm.widget.DialogControl.State.Displayed
-import me.dmdev.rxpm.widget.DialogControl.State.NotDisplayed
+import me.dmdev.rxpm.widget.DialogControl.Display.Absent
+import me.dmdev.rxpm.widget.DialogControl.Display.Displayed
 
 /**
  *
@@ -35,7 +35,7 @@ import me.dmdev.rxpm.widget.DialogControl.State.NotDisplayed
  */
 class DialogControl<T, R> internal constructor(pm: PresentationModel) {
 
-    internal val displayed = pm.State<State>(NotDisplayed)
+    val displayed = pm.State<Display>(Absent)
     private val result = pm.Action<R>()
 
     /**
@@ -65,7 +65,7 @@ class DialogControl<T, R> internal constructor(pm: PresentationModel) {
             .takeUntil(
                 displayed.relay
                     .skip(1)
-                    .filter { it == NotDisplayed }
+                    .filter { it == Absent }
             )
             .firstElement()
     }
@@ -83,13 +83,13 @@ class DialogControl<T, R> internal constructor(pm: PresentationModel) {
      */
     fun dismiss() {
         if (displayed.valueOrNull is Displayed<*>) {
-            displayed.relay.accept(NotDisplayed)
+            displayed.relay.accept(Absent)
         }
     }
 
-    internal sealed class State {
-        class Displayed<T>(val data: T) : State()
-        object NotDisplayed : State()
+    sealed class Display {
+        data class Displayed<T>(val data: T) : Display()
+        object Absent : Display()
     }
 }
 
@@ -128,7 +128,7 @@ internal inline fun <T, R> DialogControl<T, R>.bind(
                     dialog = createDialog(it.data as T, this)
                     dialog?.setOnDismissListener { this.dismiss() }
                     dialog?.show()
-                } else if (it === NotDisplayed) {
+                } else if (it === Absent) {
                     closeDialog()
                 }
             }

--- a/rxpm/src/test/kotlin/me/dmdev/rxpm/widget/DialogControlTest.kt
+++ b/rxpm/src/test/kotlin/me/dmdev/rxpm/widget/DialogControlTest.kt
@@ -1,8 +1,8 @@
 package me.dmdev.rxpm.widget
 
 import me.dmdev.rxpm.PresentationModel
-import me.dmdev.rxpm.widget.DialogControl.State.Displayed
-import me.dmdev.rxpm.widget.DialogControl.State.NotDisplayed
+import me.dmdev.rxpm.widget.DialogControl.Display.Displayed
+import me.dmdev.rxpm.widget.DialogControl.Display.Absent
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertTrue
@@ -28,7 +28,7 @@ class DialogControlTest {
     @Test fun removedOnResult() {
         dialogControl.showForResult(Unit).subscribe()
         dialogControl.sendResult(Unit)
-        assertTrue { dialogControl.displayed.value === NotDisplayed }
+        assertTrue { dialogControl.displayed.value === Absent }
     }
 
     @Test fun acceptOneResult() {
@@ -45,7 +45,7 @@ class DialogControlTest {
     @Test fun removedOnDismiss() {
         dialogControl.showForResult(Unit).subscribe()
         dialogControl.dismiss()
-        assertTrue { dialogControl.displayed.value === NotDisplayed }
+        assertTrue { dialogControl.displayed.value === Absent }
     }
 
     @Test fun cancelDialog() {
@@ -68,9 +68,9 @@ class DialogControlTest {
         displayedObserver
             .assertSubscribed()
             .assertValueCount(4)
-            .assertValueAt(0, NotDisplayed)
+            .assertValueAt(0, Absent)
             .assertValueAt(1) { it is Displayed<*> }
-            .assertValueAt(2, NotDisplayed)
+            .assertValueAt(2, Absent)
             .assertValueAt(3) { it is Displayed<*> }
             .assertNoErrors()
 


### PR DESCRIPTION
Exposed the `displayed` property of the DialogControl to ease testing and allow custom bindings for the dialog control.
Also fixed #26  here and increased version of Kotlin.

Proposed release version: 1.2.1.
Proposed release notes: 
- Exposed the DialogControl's `displayed` property.
- Fix #26. 