### PR TITLE
Fix unnecessary operator call

### DIFF
--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/PmExtensions.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/PmExtensions.kt
@@ -109,10 +109,8 @@ inline fun <T> Observable<T>.bufferWhileIdle(
                             .filter { it.not() }
                     }
                 )
-                .map {
+                .flatMapIterable {
                     if (bufferSize != null) it.takeLast(bufferSize) else it
                 }
-                .flatMapIterable { it }
-
         )
 }

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/PmExtensions.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/PmExtensions.kt
@@ -66,8 +66,8 @@ inline fun <T> Observable<T>.skipWhileInProgress(progressState: Observable<Boole
                 Pair(t, inProgress)
             }
         )
-        .filter { !it.second }
-        .map { it.first }
+        .filter { (_, inProgress) -> !inProgress }
+        .map { (item, _) -> item }
 }
 
 /**


### PR DESCRIPTION
Remove unnecessary identity call (flatMapIterable { it })