### PR TITLE
Convenient extensions of state and action

### DIFF
--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
@@ -24,15 +24,17 @@ class Action<T> internal constructor(internal val pm: PresentationModel) {
 }
 
 /**
- * Creates the [Action] and optionally sets up the [action chain][actionChain].
- * The chain will be unsubscribed ON [DESTROY][PresentationModel.Lifecycle.DESTROYED].
+ * Creates the [Action].
+ * Optionally subscribes the [action chain][actionChain] to this action.
+ * This chain will be unsubscribed ON [DESTROY][PresentationModel.Lifecycle.DESTROYED].
  */
 fun <T> PresentationModel.action(
     actionChain: (Observable<T>.() -> Observable<*>)? = null
 ): Action<T> {
     val action = Action<T>(pm = this)
-    actionChain?.let {
-        it.invoke(action.relay)
+    actionChain?.let { chain ->
+        action.relay
+            .chain()
             .retry()
             .subscribe()
             .untilDestroy()

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
@@ -24,16 +24,19 @@ class Action<T> internal constructor(internal val pm: PresentationModel) {
 }
 
 /**
- * Creates the [Action] and sets up the [action chain][actionChain].
+ * Creates the [Action] and optionally sets up the [action chain][actionChain].
+ * The chain will be unsubscribed ON [DESTROY][PresentationModel.Lifecycle.DESTROYED].
  */
 fun <T> PresentationModel.action(
     actionChain: (Observable<T>.() -> Observable<*>)? = null
 ): Action<T> {
     val action = Action<T>(pm = this)
-    actionChain?.invoke(action.relay)
-        ?.retry()
-        ?.subscribe()
-        ?.untilDestroy()
+    actionChain?.let {
+        it.invoke(action.relay)
+            .retry()
+            .subscribe()
+            .untilDestroy()
+    }
     return action
 }
 

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
@@ -24,23 +24,16 @@ class Action<T> internal constructor(internal val pm: PresentationModel) {
 }
 
 /**
- * Creates the [Action].
- */
-fun <T> PresentationModel.action(): Action<T> {
-    return Action(this)
-}
-
-/**
  * Creates the [Action] and sets up the [action chain][actionChain].
  */
 fun <T> PresentationModel.action(
-    actionChain: Observable<T>.() -> Observable<*>
+    actionChain: (Observable<T>.() -> Observable<*>)? = null
 ): Action<T> {
-    val action = action<T>()
-    actionChain(action.relay)
-        .retry()
-        .subscribe()
-        .untilDestroy()
+    val action = Action<T>(pm = this)
+    actionChain?.invoke(action.relay)
+        ?.retry()
+        ?.subscribe()
+        ?.untilDestroy()
     return action
 }
 

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/Action.kt
@@ -31,6 +31,20 @@ fun <T> PresentationModel.action(): Action<T> {
 }
 
 /**
+ * Creates the [Action] and sets up the [action chain][actionChain].
+ */
+fun <T> PresentationModel.action(
+    actionChain: Observable<T>.() -> Observable<*>
+): Action<T> {
+    val action = action<T>()
+    actionChain(action.relay)
+        .retry()
+        .subscribe()
+        .untilDestroy()
+    return action
+}
+
+/**
  * Subscribes [Action][Action] to the observable and adds it to the subscriptions list
  * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
  * so use it ONLY in [PmView.onBindPresentationModel].

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/State.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/State.kt
@@ -92,6 +92,22 @@ fun <T> PresentationModel.state(
 }
 
 /**
+ * Creates the [State] that subscribes to [observable] until [destroy][PresentationModel.Lifecycle.DESTROYED].
+ *
+ * @param [observable] source to state consumer
+ * @param [diffStrategy] diff strategy.
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> PresentationModel.stateOf(
+    observable: Observable<T>,
+    diffStrategy: DiffStrategy<T>? = DiffByEquals as DiffStrategy<T>
+): State<T> {
+    val state = state(diffStrategy = diffStrategy)
+    observable.subscribe(state.relay).untilDestroy()
+    return state
+}
+
+ /**
  * Subscribes to the [State][State] and adds it to the subscriptions list
  * that will be CLEARED ON [UNBIND][PresentationModel.Lifecycle.UNBINDED],
  * so use it ONLY in [PmView.onBindPresentationModel].

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/State.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/State.kt
@@ -6,7 +6,6 @@ import io.reactivex.android.schedulers.*
 import io.reactivex.functions.*
 import io.reactivex.schedulers.*
 import me.dmdev.rxpm.util.*
-import java.util.function.Consumer
 
 /**
  * Reactive property for the [view's][PmView] state.

--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/State.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/State.kt
@@ -94,16 +94,18 @@ fun <T> PresentationModel.state(
 /**
  * Creates the [State] that subscribes to [observable] until [destroy][PresentationModel.Lifecycle.DESTROYED].
  *
- * @param [observable] source to state consumer
+ * @param [initialValue] initial value.
  * @param [diffStrategy] diff strategy.
+ * @param [observable] source to state consumer.
  */
 @Suppress("UNCHECKED_CAST")
 fun <T> PresentationModel.stateOf(
-    observable: Observable<T>,
-    diffStrategy: DiffStrategy<T>? = DiffByEquals as DiffStrategy<T>
+    initialValue: T? = null,
+    diffStrategy: DiffStrategy<T>? = DiffByEquals as DiffStrategy<T>,
+    observable: (() -> Observable<T>)
 ): State<T> {
-    val state = state(diffStrategy = diffStrategy)
-    observable.subscribe(state.relay).untilDestroy()
+    val state = state(initialValue = initialValue, diffStrategy = diffStrategy)
+    observable().subscribe(state.relay).untilDestroy()
     return state
 }
 

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/counter/CounterPm.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/counter/CounterPm.kt
@@ -10,13 +10,13 @@ class CounterPm : PresentationModel() {
 
     val count = state(initialValue = 0)
 
-    val minusButtonEnabled = stateOf(
+    val minusButtonEnabled = stateOf {
         count.observable.map { it > 0 }
-    )
+    }
 
-    val plusButtonEnabled = stateOf(
+    val plusButtonEnabled = stateOf {
         count.observable.map { it < MAX_COUNT }
-    )
+    }
 
     val minusButtonClicks = action<Unit> {
         this.filter { count.value > 0 }

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/counter/CounterPm.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/counter/CounterPm.kt
@@ -10,11 +10,11 @@ class CounterPm : PresentationModel() {
 
     val count = state(initialValue = 0)
 
-    val minusButtonEnabled = stateOf {
+    val minusButtonEnabled = state {
         count.observable.map { it > 0 }
     }
 
-    val plusButtonEnabled = stateOf {
+    val plusButtonEnabled = state {
         count.observable.map { it < MAX_COUNT }
     }
 

--- a/sample/src/main/kotlin/me/dmdev/rxpm/sample/counter/CounterPm.kt
+++ b/sample/src/main/kotlin/me/dmdev/rxpm/sample/counter/CounterPm.kt
@@ -9,35 +9,24 @@ class CounterPm : PresentationModel() {
     }
 
     val count = state(initialValue = 0)
-    val minusButtonEnabled = state(false)
-    val plusButtonEnabled = state(false)
 
-    val minusButtonClicks = action<Unit>()
-    val plusButtonClicks = action<Unit>()
+    val minusButtonEnabled = stateOf(
+        count.observable.map { it > 0 }
+    )
 
-    override fun onCreate() {
-        super.onCreate()
+    val plusButtonEnabled = stateOf(
+        count.observable.map { it < MAX_COUNT }
+    )
 
-        count.observable
-            .map { it > 0 }
-            .subscribe(minusButtonEnabled.consumer)
-            .untilDestroy()
-
-        count.observable
-            .map { it < MAX_COUNT }
-            .subscribe(plusButtonEnabled.consumer)
-            .untilDestroy()
-
-        minusButtonClicks.observable
-            .filter { count.value > 0 }
+    val minusButtonClicks = action<Unit> {
+        this.filter { count.value > 0 }
             .map { count.value - 1 }
-            .subscribe(count.consumer)
-            .untilDestroy()
+            .doOnNext(count.consumer)
+    }
 
-        plusButtonClicks.observable
-            .filter { count.value < MAX_COUNT }
+    val plusButtonClicks = action<Unit> {
+        this.filter { count.value < MAX_COUNT }
             .map { count.value + 1 }
-            .subscribe(count.consumer)
-            .untilDestroy()
+            .doOnNext(count.consumer)
     }
 }


### PR DESCRIPTION
In many cases, the state is a simple consumer of storage or another state. In this case, it is convenient to have an extension function that takes a data source and subscribes to it. This saves us from boilerplate code and makes the code more declarative:

`val items = stateOf(repositoryObservable)`

A similar problem exists when describing an action. You must subscribe to it and correctly resubscribe when you receive an error. The following code describes an action chain:

```
val buttonClicks = action<Unit> {
    this.filter { }
        .doOnNext { } 
}
```